### PR TITLE
Download MAX_BLOCK_TAGS blocks when running remote

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,11 @@ care of adding convenience offsets to the wxHexEditor cache, which can be used
 to quickly locate internal pages of a B-Tree, for example.  The wxHexEditor
 shortcut for accessing the offsets is Ctrl + G.
 
+The convenience scripts will download a portion of the relation using psql in
+the event of not finding relation files at the expected location on the
+filesystem.  For the fallback to work, `contrib/pageinspect` must be installed
+and tagging must start at the beginning of the relation file (see `hexedit.cfg`).
+
 The convenience scripts automate away starting pg_hexedit in test environments,
 but it is still highly recommended that you familiarize yourself with
 PostgreSQL's file layout.  See: [PostgreSQL documentation - Database File
@@ -182,11 +187,12 @@ mind, where __the database should only contain disposable test data__.
 
 Convenience script assumptions:
 
-* The scripts assume that they're run as an OS user that has the operating
-  system level permissions needed to open/read all PostgreSQL relation files,
-  using the same absolute paths as PostgreSQL.  Be very careful if the Postgres
-  data directory is containerized; a convenience script might open relation
-  files from an unrelated installation if this assumption is not fully met.
+* The scripts initially assume that they're run as an OS user that has the
+  operating system level permissions needed to open/read all PostgreSQL
+  relation files, using the same absolute paths as PostgreSQL.  Be very careful
+  if the Postgres data directory is containerized; a convenience script might
+  open relation files from an unrelated installation if this assumption is not
+  fully met.
 
 * Most convenience scripts rely on `CREATE EXTENSION IF NOT EXISTS pageinspect`
   running and making available various SQL-callable functions.  These functions

--- a/__open_relation
+++ b/__open_relation
@@ -67,11 +67,31 @@ then
   exit 1
 fi
 
-# Generate tags at a path that we know wxHexEditor will look for them:
+# Check if data file exists locally, download $MAX_BLOCK_TAGS to /tmp if it doesn't
 FULLPATH="$PGDATA/$RFN"
-echo "Running pg_hexedit against $FULLPATH, the first segment in relation $relname..."
-echo "Note: Only blocks $MIN_BLOCK_TAGS - $MAX_BLOCK_TAGS will be annotated, to keep overhead low"
+if [ -f "$FULLPATH" ]; then
+  echo "Running pg_hexedit against $FULLPATH, the first segment in relation $relname..."
+  echo "Note: Only blocks $MIN_BLOCK_TAGS - $MAX_BLOCK_TAGS will be annotated, to keep overhead low"
+else
+  PAGEINSPECT_INSTALLED=$(psql -XAtc "select count(*) from pg_extension where extname='pageinspect'")
+  if (( PAGEINSPECT_INSTALLED && MIN_BLOCK_TAGS == 0 )); then
+    FULLPATH=/tmp/$(basename "$RFN")
+    echo "Downloading first $MAX_BLOCK_TAGS blocks from relation $relname to $FULLPATH..."
+    psql -XAtc "SELECT encode(get_raw_page('$relname', block::int4),'base64')
+                FROM generate_series(0, least(pg_relation_size('$relname') / 8192 - 1, $MAX_BLOCK_TAGS))
+                block" | base64 -d > "$FULLPATH"
+  else
+    echo "File $FULLPATH doesn't exist."
+    if (( MIN_BLOCK_TAGS == 0 )); then
+      echo "Tip: Install pageinspect to automatically download remote files."
+    else
+      echo "Cannot automatically download remote files when MIN_BLOCK_TAGS is non-zero."
+    fi
+    exit 1
+  fi
+fi
 
+# Generate tags at a path that we know wxHexEditor will look for them:
 if ! ./pg_hexedit -D "$ATTRLIST" -z -R "$MIN_BLOCK_TAGS" "$MAX_BLOCK_TAGS" "$FULLPATH" > "$FULLPATH.tags"
 then
   echo "Error encountered by pg_hexedit. Could not generate all tags."

--- a/hexedit.cfg
+++ b/hexedit.cfg
@@ -6,6 +6,7 @@
 export HEXEDITOR="../wxHexEditor/wxHexEditor"
 
 # Only blocks in the range $MIN_BLOCK_TAGS - $MAX_BLOCK_TAGS receive tags:
+# (Note that setting MIN_BLOCK_TAGS>0 will disable fallback download of files.)
 export MIN_BLOCK_TAGS=0
 export MAX_BLOCK_TAGS=200
 


### PR DESCRIPTION
Simple and useful addition to use pageinspect (if available) to download the first few blocks of the relation for remote inspection.

Only downloads MAX_BLOCK_TAGS blocks and saves in /tmp. If pageinspect is not installed, shows a friendly message.