### PR TITLE
Allow building on Ubuntu 18.04, 20.40, etc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ PG_CONFIG = pg_config
 PGSQL_CFLAGS = $(shell $(PG_CONFIG) --cflags)
 PGSQL_INCLUDE_DIR = $(shell $(PG_CONFIG) --includedir-server)
 PGSQL_LDFLAGS = $(shell $(PG_CONFIG) --ldflags)
-PGSQL_LIB_DIR = $(shell $(PG_CONFIG) --libdir)
+PGSQL_LIB_DIR = $(shell $(PG_CONFIG) --pkglibdir)
 PGSQL_BIN_DIR = $(shell $(PG_CONFIG) --bindir)
 
 DISTFILES= README.md Makefile pg_hexedit.c pg_filenodemapdata.c


### PR DESCRIPTION
`--libdir` returns `/usr/lib/x86_64-linux-gnu`, while on Ubuntu 18.04, 20.04, etc
it's `/usr/lib/postgresql/13/lib`.

`--pkglibdir` does the trick.

Haven't tested on any other Linux distros rather than Ubuntu 20.04 (with Postgres 13)

Thanks @CyberDem0n for the tip (https://github.com/reorg/pg_repack/commit/021d0b03933ece4c668b4bed19d2e4701d631e3c#diff-8c4ff4d047a8a7015d30cd0d0ff78161)