### PR TITLE
Improve setup guide for macOS users on Apple Silicon

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,17 +182,17 @@ to PostgreSQL binaries (Postgres installed via Homebrew –
 5. In hexedit.cfg, check `export HEXEDITOR`, it needs to point to
 the `wxHexEditor` binary (created above)
 
-### Alternative: Using Hex Fiend (for Apple Silicon when wxHexEditor fails)
+### Alternative: Using ImHex (recommended for Apple Silicon when wxHexEditor fails)
 
-If wxHexEditor compilation fails, you can still use pg_hexedit to analyze PostgreSQL files:
+If wxHexEditor compilation fails, ImHex provides a modern alternative with pattern matching capabilities:
 
-1. Install Hex Fiend: `brew install --cask hex-fiend`
-2. Build pg_hexedit only: `make` (in pg_hexedit directory)  
-3. Generate XML annotations: `./pg_hexedit file > file.tags`
-4. Open the file in Hex Fiend for hex viewing
-5. Reference the `.tags` file separately for PostgreSQL structure information
+1. Install ImHex: `brew install --cask imhex`
+2. Build pg_hexedit only: `make` (in pg_hexedit directory)
+3. Open PostgreSQL files directly in ImHex for hex viewing with built-in analysis tools
 
-**Note:** Hex Fiend does not automatically import wxHexEditor XML tags, but the generated annotations are still valuable for understanding PostgreSQL page structure.
+ImHex offers advanced pattern matching and data structure visualization that can help analyze PostgreSQL page layouts, though it uses its own pattern language rather than importing wxHexEditor XML tags.
+
+**Alternative:** You can still generate pg_hexedit XML annotations (`./pg_hexedit file > file.tags`) and reference them alongside any hex editor for detailed PostgreSQL structure information.
 
 Note: The convenience scripts set `$HOME` to the current working directory so
 that wxHexEditor reads its settings from a convenience-script-generated

--- a/README.md
+++ b/README.md
@@ -171,15 +171,14 @@ with installed [Homebrew](https://brew.sh/)):
 
 1. `brew install automake autoconf libtool wxmac`
 
-**Note for Apple Silicon (M1/M2/M3) Macs:** Building wxHexEditor from source requires some modifications but is possible. The SSE intrinsics are properly wrapped with conditional compilation, so the build should succeed with the Python configuration fix below.
-
 2. Get [wxHexEditor source code](https://github.com/EUA/wxHexEditor) and edit
-`Makefile` removing the line mentioning OpenMP (`LIBS += -lgomp`). Also configure with Python: `cd udis86 && ./configure --with-python=/opt/homebrew/bin/python3`
-3. Build wxHexEditor (`make`)
-4. Get pg_hexedit source code, build (`make`) with `$PATH` including path
+`Makefile` removing the line mentioning OpenMP (`LIBS += -lgomp`)
+3. **For Apple Silicon (M1/M2/M3) Macs:** Configure udis86 with Python: `cd udis86 && ./configure --with-python=/opt/homebrew/bin/python3`
+4. Build wxHexEditor (`make`)
+5. Get pg_hexedit source code, build (`make`) with `$PATH` including path
 to PostgreSQL binaries (Postgres installed via Homebrew – 
 `brew install postgresql` – should be enough)
-5. In hexedit.cfg, check `export HEXEDITOR`, it needs to point to
+6. In hexedit.cfg, check `export HEXEDITOR`, it needs to point to
 the `wxHexEditor` binary (created above)
 
 ### Alternative: Using ImHex (if preferred)

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ git repo, and following the instructions that it provides:
 
 ## Initial setup on MacOS
 
-These steps should help you install pg_hexedit on MacOS (tested on Catalina and Apple Silicon
+These steps should help you install pg_hexedit on MacOS (tested on Catalina and Apple Silicon M1 on Sequoia 15.6
 with installed [Homebrew](https://brew.sh/)):
 
 1. `brew install automake autoconf libtool wxmac`
@@ -181,15 +181,6 @@ to PostgreSQL binaries (Postgres installed via Homebrew –
 6. In hexedit.cfg, check `export HEXEDITOR`, it needs to point to
 the `wxHexEditor` binary (created above)
 
-### Alternative: Using ImHex (if preferred)
-
-If you prefer a modern hex editor with pattern matching capabilities:
-
-1. Install ImHex: `brew install --cask imhex`
-2. Build pg_hexedit only: `make` (in pg_hexedit directory)
-3. Open PostgreSQL files directly in ImHex for hex viewing with built-in analysis tools
-
-ImHex offers advanced pattern matching and data structure visualization, though it uses its own pattern language rather than importing wxHexEditor XML tags. For full pg_hexedit functionality with XML annotations, wxHexEditor remains the recommended choice.
 
 Note: The convenience scripts set `$HOME` to the current working directory so
 that wxHexEditor reads its settings from a convenience-script-generated

--- a/README.md
+++ b/README.md
@@ -166,18 +166,30 @@ git repo, and following the instructions that it provides:
 
 ## Initial setup on MacOS
 
-These steps should help you install pg_hexedit on MacOS (tested on Catalina
+These steps should help you install pg_hexedit on MacOS (tested on Catalina and Apple Silicon
 with installed [Homebrew](https://brew.sh/)):
 
 1. `brew install automake autoconf libtool wxmac`
-1. Get [wxHexEditor source code](https://github.com/EUA/wxHexEditor) and edit
-`Makefile` removing the line mentioning OpenMP (`LIBS += -lgomp`)
-1. Build wxHexEditor (`make`)
-1. Get pg_hexedit source code, build (`make`) with `$PATH` including path
+
+**Note for Apple Silicon (M1/M2/M3) Macs:** Building wxHexEditor from source currently fails due to x86 SSE intrinsics compatibility issues. Consider using an alternative hex editor like [Hex Fiend](https://hexfiend.com/) (`brew install --cask hex-fiend`) and configure `hexedit.cfg` accordingly.
+
+2. Get [wxHexEditor source code](https://github.com/EUA/wxHexEditor) and edit
+`Makefile` removing the line mentioning OpenMP (`LIBS += -lgomp`). Also configure with Python: `cd udis86 && ./configure --with-python=/opt/homebrew/bin/python3`
+3. Build wxHexEditor (`make`)
+4. Get pg_hexedit source code, build (`make`) with `$PATH` including path
 to PostgreSQL binaries (Postgres installed via Homebrew – 
 `brew install postgresql` – should be enough)
-1. In hexedit.cfg, check `export HEXEDITOR`, it needs to point to
+5. In hexedit.cfg, check `export HEXEDITOR`, it needs to point to
 the `wxHexEditor` binary (created above)
+
+### Alternative: Using Hex Fiend (recommended for Apple Silicon)
+
+If wxHexEditor compilation fails:
+
+1. Install Hex Fiend: `brew install --cask hex-fiend`
+2. Build pg_hexedit only: `make` (in pg_hexedit directory)  
+3. Edit `hexedit.cfg` to set: `export HEXEDITOR="open -a 'Hex Fiend'"` (or path to your preferred hex editor)
+4. Generate tags manually: `./pg_hexedit file > file.tags` then open file in Hex Fiend
 
 Note: The convenience scripts set `$HOME` to the current working directory so
 that wxHexEditor reads its settings from a convenience-script-generated

--- a/README.md
+++ b/README.md
@@ -182,14 +182,17 @@ to PostgreSQL binaries (Postgres installed via Homebrew –
 5. In hexedit.cfg, check `export HEXEDITOR`, it needs to point to
 the `wxHexEditor` binary (created above)
 
-### Alternative: Using Hex Fiend (recommended for Apple Silicon)
+### Alternative: Using Hex Fiend (for Apple Silicon when wxHexEditor fails)
 
-If wxHexEditor compilation fails:
+If wxHexEditor compilation fails, you can still use pg_hexedit to analyze PostgreSQL files:
 
 1. Install Hex Fiend: `brew install --cask hex-fiend`
 2. Build pg_hexedit only: `make` (in pg_hexedit directory)  
-3. Edit `hexedit.cfg` to set: `export HEXEDITOR="open -a 'Hex Fiend'"` (or path to your preferred hex editor)
-4. Generate tags manually: `./pg_hexedit file > file.tags` then open file in Hex Fiend
+3. Generate XML annotations: `./pg_hexedit file > file.tags`
+4. Open the file in Hex Fiend for hex viewing
+5. Reference the `.tags` file separately for PostgreSQL structure information
+
+**Note:** Hex Fiend does not automatically import wxHexEditor XML tags, but the generated annotations are still valuable for understanding PostgreSQL page structure.
 
 Note: The convenience scripts set `$HOME` to the current working directory so
 that wxHexEditor reads its settings from a convenience-script-generated

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ with installed [Homebrew](https://brew.sh/)):
 
 1. `brew install automake autoconf libtool wxmac`
 
-**Note for Apple Silicon (M1/M2/M3) Macs:** Building wxHexEditor from source currently fails due to x86 SSE intrinsics compatibility issues. Consider using an alternative hex editor like [Hex Fiend](https://hexfiend.com/) (`brew install --cask hex-fiend`) and configure `hexedit.cfg` accordingly.
+**Note for Apple Silicon (M1/M2/M3) Macs:** Building wxHexEditor from source requires some modifications but is possible. The SSE intrinsics are properly wrapped with conditional compilation, so the build should succeed with the Python configuration fix below.
 
 2. Get [wxHexEditor source code](https://github.com/EUA/wxHexEditor) and edit
 `Makefile` removing the line mentioning OpenMP (`LIBS += -lgomp`). Also configure with Python: `cd udis86 && ./configure --with-python=/opt/homebrew/bin/python3`
@@ -182,17 +182,15 @@ to PostgreSQL binaries (Postgres installed via Homebrew –
 5. In hexedit.cfg, check `export HEXEDITOR`, it needs to point to
 the `wxHexEditor` binary (created above)
 
-### Alternative: Using ImHex (recommended for Apple Silicon when wxHexEditor fails)
+### Alternative: Using ImHex (if preferred)
 
-If wxHexEditor compilation fails, ImHex provides a modern alternative with pattern matching capabilities:
+If you prefer a modern hex editor with pattern matching capabilities:
 
 1. Install ImHex: `brew install --cask imhex`
 2. Build pg_hexedit only: `make` (in pg_hexedit directory)
 3. Open PostgreSQL files directly in ImHex for hex viewing with built-in analysis tools
 
-ImHex offers advanced pattern matching and data structure visualization that can help analyze PostgreSQL page layouts, though it uses its own pattern language rather than importing wxHexEditor XML tags.
-
-**Alternative:** You can still generate pg_hexedit XML annotations (`./pg_hexedit file > file.tags`) and reference them alongside any hex editor for detailed PostgreSQL structure information.
+ImHex offers advanced pattern matching and data structure visualization, though it uses its own pattern language rather than importing wxHexEditor XML tags. For full pg_hexedit functionality with XML annotations, wxHexEditor remains the recommended choice.
 
 Note: The convenience scripts set `$HOME` to the current working directory so
 that wxHexEditor reads its settings from a convenience-script-generated


### PR DESCRIPTION
(try 2)

## Summary
Updates macOS installation instructions to support Apple Silicon (M1/M2/M3) Macs with tested build steps for wxHexEditor and pg_hexedit.

## Changes
- Add Apple Silicon-specific Python configuration for udis86 dependency
- Update testing information to include Sequoia 15.6 
- Remove unnecessary alternative hex editor options
- Streamline installation workflow

## Problem
Apple Silicon users encountered build failures due to missing Python configuration for the udis86 dependency during wxHexEditor compilation.

## Solution
Added step 3 with explicit Apple Silicon identification and exact Python configuration command needed for successful builds.

## Testing
Verified on Apple Silicon M1 running macOS Sequoia 15.6. wxHexEditor builds successfully and pg_hexedit XML annotations display correctly with full functionality.

Documentation-only changes that maintain backward compatibility with Intel Mac instructions.

<img width="1308" height="850" alt="Screenshot 2025-08-21 at 11 58 57" src="https://github.com/user-attachments/assets/aa5f052a-7608-42c6-a8f0-f2d65ddeb4b8" />

